### PR TITLE
usuwanie komentowanych artykułów, focus zachowany, zmiana collapse btn

### DIFF
--- a/src/main/java/pl/edu/pw/blog/data/Article.java
+++ b/src/main/java/pl/edu/pw/blog/data/Article.java
@@ -26,7 +26,8 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotBlank;
 
-
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import lombok.Data;
@@ -100,7 +101,8 @@ public class Article implements Serializable{
 	}
 	
 	
-	@OneToMany(cascade = CascadeType.ALL, mappedBy = "article",fetch=FetchType.EAGER)
+	@OneToMany(mappedBy = "article",fetch=FetchType.EAGER,cascade = CascadeType.ALL, orphanRemoval = true)
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	private List<Comments> comments = new ArrayList<>();
 	
 	

--- a/src/main/java/pl/edu/pw/blog/data/ArticleRepository.java
+++ b/src/main/java/pl/edu/pw/blog/data/ArticleRepository.java
@@ -38,4 +38,7 @@ public interface ArticleRepository extends PagingAndSortingRepository<Article, L
 	  @Query("select max(a.modifiedAt) from Article a")
 	  Optional<Date> findMaxModifiedDate();
 	  
+	  
+	 
+	  
 	}

--- a/src/main/java/pl/edu/pw/blog/data/CommentRepository.java
+++ b/src/main/java/pl/edu/pw/blog/data/CommentRepository.java
@@ -1,6 +1,7 @@
 package pl.edu.pw.blog.data;
 
 
+
 import org.springframework.data.repository.CrudRepository;
 
 
@@ -16,5 +17,5 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface CommentRepository extends CrudRepository<Comments, Long> {
 
-
+	
 }

--- a/src/main/java/pl/edu/pw/blog/data/Comments.java
+++ b/src/main/java/pl/edu/pw/blog/data/Comments.java
@@ -7,11 +7,9 @@ import java.util.*;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.PrePersist;
 import javax.persistence.Table;
@@ -73,15 +71,13 @@ public class Comments implements Serializable{
 
     @ToString.Exclude
     @NonNull
-    @ManyToOne(fetch=FetchType.EAGER)
-    @JoinColumn(name="author_id", nullable=false)
+    @ManyToOne
     private User user;
 
 
     @ToString.Exclude
     @NonNull
-    @ManyToOne(fetch=FetchType.EAGER)
-    @JoinColumn(name="article_id", nullable=false)
+    @ManyToOne
     private Article article;
 
 

--- a/src/main/java/pl/edu/pw/blog/data/User.java
+++ b/src/main/java/pl/edu/pw/blog/data/User.java
@@ -19,6 +19,8 @@ import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.
                                           SimpleGrantedAuthority;
@@ -69,7 +71,8 @@ public class User implements Comparable<User>, UserDetails{
 	@ManyToMany(mappedBy = "likers",fetch=FetchType.EAGER)
 	private Set<Article> likedArticles = new HashSet<>();
 	
-	@OneToMany(cascade = CascadeType.ALL, mappedBy = "user")
+	@OneToMany(mappedBy = "user", fetch=FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	private List<Comments> comments = new ArrayList<>();
 	
 	

--- a/src/main/java/pl/edu/pw/blog/web/ArticlesController.java
+++ b/src/main/java/pl/edu/pw/blog/web/ArticlesController.java
@@ -288,11 +288,13 @@ public class ArticlesController{
 	 * 
 	 * @author Michal
 	 */
+	
 	@PostMapping(value = "/articles/delete/{id}")
 	public String deleteArticle(@PathVariable Long id, Model model,RedirectAttributes redirectAttributes) {
 		
 		
 		if (isAuthor((User) model.getAttribute("user"),id)){
+			
 			articleRepo.deleteById(id);
 			redirectAttributes.addFlashAttribute("message","Usunięto artykuł o id: " + id);
 		} else {
@@ -364,8 +366,6 @@ public class ArticlesController{
 			
 			model.addAttribute("errors",errors.getAllErrors());
 			
-			
-			//return "redirect:/articles/edit/"+modifiedArticle.getId();
 			return "edit";
 		  }
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -7,3 +7,5 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=test
 spring.datasource.password=test
 spring.jpa.hibernate.ddl-auto=create-drop
+logging.level.org.springframework.web=debug
+#spring.jpa.show-sql=true

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -3,4 +3,5 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 #spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.PostgreSQLDialect             
 spring.datasource.username=${DB_USER_NAME}
 spring.datasource.password=${DB_USER_PASSWORD}
-spring.jpa.hibernate.ddl-auto=update                    
+spring.jpa.hibernate.ddl-auto=update
+logging.level.org.springframework.web=info                 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,3 @@
 spring.profiles.active=dev
 logging.file.name=app.log
-logging.level.org.springframework.web=debug
-#spring.servlet.multipart.enabled=true
-#spring.servlet.multipart.max-file-size=10MB
-#spring.servlet.multipart.max-request-size=10MB
-#spring.servlet.multipart.location=${java.io.tmpdir}
 server.error.whitelabel.enabled=false

--- a/src/main/resources/templates/articles.html
+++ b/src/main/resources/templates/articles.html
@@ -57,7 +57,7 @@
          
     </div>
     <div id="add_post "class="row fixed-bottom bg-light border-top border-primary">
-    <button class="btn btn-primary btn-lg ds-flex align-content-center" type="button" data-bs-toggle="collapse" data-bs-target="#collapseForm" aria-expanded="false"><i class="material-icons">add</i>&nbsp;<span>Utwórz nowy artykuł</span></button>
+    <button id="add_button" class="btn btn-primary btn-lg ds-flex align-content-center" type="button" data-bs-toggle="collapse" data-bs-target="#collapseForm" aria-expanded="false"><i class="material-icons">add</i>&nbsp;<span>Utwórz nowy artykuł</span></button>
       
         <div class="collapse" id="collapseForm">
         
@@ -92,6 +92,12 @@
 			  		$(this).val(getSavedValue($(this).attr('id')));
 			  	});
 				
+				$("#collapseForm").on("hide.bs.collapse", function(){
+				    $("#add_button").html('<i class="material-icons">add</i>&nbsp;<span>Utwórz nowy artykuł</span>');
+				  });
+				  $("#collapseForm").on("show.bs.collapse", function(){
+				    $("#add_button").html('<i class="material-icons">remove</i>&nbsp;<span>Zwiń panel</span>');
+				  });
 			
 			   var countLikes = /*[[${likesNumber}]]*/ 0;
 			   var countComments = /*[[${commentsNumber}]]*/ 0;
@@ -115,11 +121,21 @@
 		                    	countComments < data.commentsNumber
 		                    ) {
 		                        
+		                    	
+		                    	if (typeof $(".comments_textareas").filter(":focus").attr("id") !== undefined){
+		                    		var focused = $(".comments_textareas").filter(":focus").attr("id");
+		                    	}
+		                    	
 		                        $.get("/refreshArticles").done(function (fragment) { 
 		                           	$("#articles_list").html(fragment);
 		                           	$('.comments_textareas').each(function(i,obj){
 			        			  		$(this).val(getSavedValue($(this).attr('id')));
 			        			  	});
+		                           	if (typeof focused !== undefined){
+		                           		$("#" + focused).focus();
+		                           	};
+		                           	
+		                           	
 		                           	if (authorsNumber > data.authorsList.length || authorsNumber < data.authorsList.length){
 		                           		var filterVal = $("#filter option:selected").val();
 		                     

--- a/src/test/java/pl/edu/pw/blog/BlogApplicationTests.java
+++ b/src/test/java/pl/edu/pw/blog/BlogApplicationTests.java
@@ -5,38 +5,27 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-import java.util.HashMap;
 import java.util.Map;
-
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
-
-
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
 
 
 import pl.edu.pw.blog.data.User;
-import pl.edu.pw.blog.data.UserRepository;
 import pl.edu.pw.blog.security.RegistrationController;
 import pl.edu.pw.blog.security.UserService;
 
@@ -69,8 +58,7 @@ class BlogApplicationTests {
 	private MockMvc mockMvc;
 	
 	
-	@Autowired
-	private UserRepository userRepo;
+
 	
 
 	@Autowired


### PR DESCRIPTION
Poprawiony bug usuwania artykułów, które posiadały komentarze (adnotacja
OnDelete)
Focus na comment_textarea zachowany po przeładowaniu
Zmiennna treść przycisku dla collapse